### PR TITLE
Asset path incorrect 

### DIFF
--- a/gatsby-plugin-cockpit/helpers/asset.js
+++ b/gatsby-plugin-cockpit/helpers/asset.js
@@ -36,7 +36,7 @@ class AssetMapHelpers {
     this.createNode = createNode;
     this.collectionsItems = collectionsItems;
     this.config = config;
-    this.config.host = config.baseURL + config.folder;
+    this.config.host = config.baseURL;
   }
 
   addAllOtherImagesPathsToAssetsArray() {
@@ -49,7 +49,7 @@ class AssetMapHelpers {
           if (entry[fieldname].path) {
             let path = entry[fieldname].path;
             if (!validUrl.isUri(path)) {
-              path = this.config.host + '/' + path;
+              path = this.config.host + path;
             }
             if (validUrl.isUri(path)) {
               this.assets.push({

--- a/gatsby-plugin-cockpit/package.json
+++ b/gatsby-plugin-cockpit/package.json
@@ -2,7 +2,7 @@
   "name": "gatsby-plugin-cockpit",
   "description": "Gatsby source plugin for Cockpit headless CMS API.",
   "author": "Paul Hayes <paul@ginetta.net>",
-  "version": "1.0.39",
+  "version": "1.0.40",
   "keywords": ["gatsby", "gatsby-plugin", "gatsby-source-plugin", "cockpit"],
   "license": "MIT",
   "dependencies": {


### PR DESCRIPTION
I'm running the latest build of Cockpit and the full asset path is returned, so the cockpit folder path is duplicated. 